### PR TITLE
Updating to support V2 of the Monero Payment Request Standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
+
+### V1
 Encode a request:
 ```ruby
 require 'monerorequest'
@@ -30,7 +32,7 @@ req = {
   "change_indicator_url" => "[some url here]"
 }
 enc = Monerorequest::Encoder.new(req)
-enc.encode(VERSION) # currently only version 1 is implemented
+enc.encode(1)
 ```
 
 Decode a request:
@@ -41,6 +43,35 @@ req = "monero-request:1:H4sIAAAAAAACAy2QS4vUQBSF/0qondA9XanqJJ3sZjEozGYW4kooKpWb
 WrEIFarzvisnEGlOOG5AVaAtSNDuw4m2nYCJsuIkGd7AWtOgHx8GVgwvBedMyxUvYYtafHrz49fT13+8nb+rNnS/nm7ff3v04vb+/fvj8w/WAcQw/3z++dDnai67tbp4cP4ouRP7787M/Z69eJtF+tNycnd/bW9/9+NUN+Ir3jnVgWSmVknrORC8
 UoCKnI6RDWw4XU7OO9y1o71BB8hH6vzFZDYFIlRFe1yTPeVblpB6YDpQC69iSD3P4DZruUtybtGxXcqZS08yrlMeYmMNF1lF+o1FULvzMxwL3C3DikAM/8jSmSpbG9NbWqll1mQtJ6jgJJqFHIe+obDQsLU22NZzn1rOKe9hGwmQ6xskYp1fjWTE
 lBaFjnBUYo9v/ANjVPGWxAQAA"
+dec = Monerorequest::Decoder.new(req)
+dec.decode
+```
+
+### V2
+Encode a request:
+```ruby
+require 'monerorequest'
+
+req = {
+  "custom_label" => "[some string here]",
+  "sellers_wallet" => "[monero main address, starts with 4]",
+  "currency" => "USD",
+  "amount" => 420.69,
+  "payment_id" => "[monero payment ID]",
+  "start_date" => "[timestamp in rfc3339 format]",
+  "schedule" => '* * 1 * *',
+  "number_of_payments" => 12,
+  "change_indicator_url" => "[some url here]"
+}
+enc = Monerorequest::Encoder.new(req)
+enc.encode(2)
+```
+
+Decode a request:
+```ruby
+require 'monerorequest'
+
+req = "monero-request:2:H4sIAAAAAAACAy2PTW/CMAyG/wrKEVFIE9rS3nbbkcPukZu4JCNNSj6Abtp/X5h2sCw/9vva/iYw++wSGdqm5v2+rXdEanAXFMYpIyH5IHKwZCA6pWU4HIL3Y6XRKHQBjdR7fMK8WDzIkL9IUecQ0Mm1KM7v5z8Qk5+FhRFfNgljKtTlecQg/CQWWGd0KZKB9TvyXwmjyixTHYNpYn0PnerZVHRRalTZYuluN9tNXWL7wmgthigeUHL5hhzfOF19O85Pc7Kt1xfVQk2Zv966hcOnttzc0inVkq43jPIKCPfEa27N6P0awmT1c+libtoILPuG33O/cKMdPgJv4mtlgpCEgvS6hVF2rGhT0fajPg1HNjBe0W6glPz8AihAH5JjAQAA"
 dec = Monerorequest::Decoder.new(req)
 dec.decode
 ```

--- a/lib/monerorequest.rb
+++ b/lib/monerorequest.rb
@@ -11,6 +11,7 @@ require_relative "monerorequest/encoder"
 require_relative "monerorequest/monero_address"
 require_relative "monerorequest/monero_payment_id"
 require_relative "monerorequest/version"
+require_relative "monerorequest/cron"
 
 module Monerorequest
   class RequestVersionError < StandardError; end

--- a/lib/monerorequest/cron.rb
+++ b/lib/monerorequest/cron.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Monerorequest
+  class Cron
+    MONTH_CODES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+    DOW_CODES = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+    DELIMITERS = /,|-|\//
+    def self.valid?(schedule)
+      parsed_schedule = self.parse(schedule)
+      return false if not parsed_schedule
+
+      return self.valid_minutes?(parsed_schedule['minutes']) && self.valid_hours?(parsed_schedule['hours']) &&
+             self.valid_days?(parsed_schedule['days']) && self.valid_months?(parsed_schedule['months'])
+             self.valid_dow?(parsed_schedule['dow'])
+    end
+
+    def self.valid_minutes?(minutes)
+      return minutes.all? { |min| ('0'..'59').member?(min) } || minutes == ["*"]
+    end
+
+    def self.valid_hours?(hours)
+      return hours.all?{ |hr| ('0'..'23').member?(hr) } || hours == ["*"]
+    end
+
+    def self.valid_days?(days)
+      return days.all?{ |dy| (1..31).member?(dy.to_i) } || days == ["*"]
+    end
+
+    def self.valid_months?(months)
+      return months.all?{ |mth| (1..12).member?(mth.to_i) || MONTH_CODES.include?(mth.downcase) } || months == ["*"]
+    end
+
+    def self.valid_dow?(dow)
+      return dow.all?{ |d| DOW_CODES.include?(d.downcase) } || dow == ["*"]
+    end
+
+    def self.parse(schedule)
+      schedule_parts = schedule.split(' ')
+      return false if schedule_parts.length != 5
+      parsed_schedule = {}
+      parsed_schedule['minutes'] = schedule_parts[0].split(DELIMITERS)
+      parsed_schedule['hours'] = schedule_parts[1].split(DELIMITERS)
+      parsed_schedule['days'] = schedule_parts[2].split(DELIMITERS)
+      parsed_schedule['months'] = schedule_parts[3].split(DELIMITERS)
+      parsed_schedule['dow'] = schedule_parts[4].split(DELIMITERS)
+
+      return parsed_schedule
+    end
+  end
+end

--- a/lib/monerorequest/cron.rb
+++ b/lib/monerorequest/cron.rb
@@ -1,50 +1,51 @@
 # frozen_string_literal: true
 
 module Monerorequest
+  # Parses and validates cron syntax string.
   class Cron
-    MONTH_CODES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
-    DOW_CODES = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
-    DELIMITERS = /,|-|\//
+    MONTH_CODES = %w[jan feb mar apr may jun jul aug sep oct nov dec].freeze
+    DOW_CODES = %w[mon tue wed thu fri sat sun].freeze
+    DELIMITERS = %r{,|-|/}.freeze
     def self.valid?(schedule)
-      parsed_schedule = self.parse(schedule)
-      return false if not parsed_schedule
+      parsed_schedule = parse(schedule)
+      return false unless parsed_schedule
 
-      return self.valid_minutes?(parsed_schedule['minutes']) && self.valid_hours?(parsed_schedule['hours']) &&
-             self.valid_days?(parsed_schedule['days']) && self.valid_months?(parsed_schedule['months'])
-             self.valid_dow?(parsed_schedule['dow'])
+      valid_minutes?(parsed_schedule["minutes"]) && valid_hours?(parsed_schedule["hours"]) &&
+        valid_days?(parsed_schedule["days"]) && valid_months?(parsed_schedule["months"]) &&
+        valid_dow?(parsed_schedule["dow"])
     end
 
     def self.valid_minutes?(minutes)
-      return minutes.all? { |min| ('0'..'59').member?(min) } || minutes == ["*"]
+      minutes.all? { |min| ("0".."59").member?(min) } || minutes == ["*"]
     end
 
     def self.valid_hours?(hours)
-      return hours.all?{ |hr| ('0'..'23').member?(hr) } || hours == ["*"]
+      hours.all? { |hr| ("0".."23").member?(hr) } || hours == ["*"]
     end
 
     def self.valid_days?(days)
-      return days.all?{ |dy| (1..31).member?(dy.to_i) } || days == ["*"]
+      days.all? { |dy| (1..31).member?(dy.to_i) } || days == ["*"]
     end
 
     def self.valid_months?(months)
-      return months.all?{ |mth| (1..12).member?(mth.to_i) || MONTH_CODES.include?(mth.downcase) } || months == ["*"]
+      months.all? { |mth| (1..12).member?(mth.to_i) || MONTH_CODES.include?(mth.downcase) } || months == ["*"]
     end
 
     def self.valid_dow?(dow)
-      return dow.all?{ |d| DOW_CODES.include?(d.downcase) } || dow == ["*"]
+      dow.all? { |d| DOW_CODES.include?(d.downcase) } || dow == ["*"]
     end
 
     def self.parse(schedule)
-      schedule_parts = schedule.split(' ')
+      schedule_parts = schedule.split
       return false if schedule_parts.length != 5
-      parsed_schedule = {}
-      parsed_schedule['minutes'] = schedule_parts[0].split(DELIMITERS)
-      parsed_schedule['hours'] = schedule_parts[1].split(DELIMITERS)
-      parsed_schedule['days'] = schedule_parts[2].split(DELIMITERS)
-      parsed_schedule['months'] = schedule_parts[3].split(DELIMITERS)
-      parsed_schedule['dow'] = schedule_parts[4].split(DELIMITERS)
 
-      return parsed_schedule
+      {
+        "minutes" => schedule_parts[0].split(DELIMITERS),
+        "hours" => schedule_parts[1].split(DELIMITERS),
+        "days" => schedule_parts[2].split(DELIMITERS),
+        "months" => schedule_parts[3].split(DELIMITERS),
+        "dow" => schedule_parts[4].split(DELIMITERS)
+      }
     end
   end
 end

--- a/lib/monerorequest/decoder.rb
+++ b/lib/monerorequest/decoder.rb
@@ -9,11 +9,13 @@ module Monerorequest
 
     def decode
       _, version, encoded_str = @request.split(":")
-      raise RequestVersionError, "Only Request Version 1 is supported." unless version == "1"
+      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1,2].include?(version.to_i)
 
       compressed_data = Base64.decode64(encoded_str)
       json_str = Zlib::GzipReader.new(StringIO.new(compressed_data)).read
-      JSON.parse(json_str)
+      decoded_hash = JSON.parse(json_str)
+      decoded_hash['version'] = version.to_i
+      decoded_hash
     end
   end
 end

--- a/lib/monerorequest/decoder.rb
+++ b/lib/monerorequest/decoder.rb
@@ -9,12 +9,12 @@ module Monerorequest
 
     def decode
       _, version, encoded_str = @request.split(":")
-      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1,2].include?(version.to_i)
+      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1, 2].include?(version.to_i)
 
       compressed_data = Base64.decode64(encoded_str)
       json_str = Zlib::GzipReader.new(StringIO.new(compressed_data)).read
       decoded_hash = JSON.parse(json_str)
-      decoded_hash['version'] = version.to_i
+      decoded_hash["version"] = version.to_i
       decoded_hash
     end
   end

--- a/lib/monerorequest/encoder.rb
+++ b/lib/monerorequest/encoder.rb
@@ -23,7 +23,7 @@ module Monerorequest
     end
 
     def encode(version)
-      raise RequestVersionError, "Only Request Version 1 is supported." unless version == 1
+      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1,2].include?(version.to_i)
 
       json_str = @request.sort.to_h.to_json.force_encoding("ascii")
       compressed_data = StringIO.new
@@ -32,7 +32,7 @@ module Monerorequest
       gz.write(json_str)
       gz.close
       encoded_str = Base64.encode64(compressed_data.string).gsub("\n", "")
-      "monero-request:1:#{encoded_str}"
+      "monero-request:#{version}:#{encoded_str}"
     end
 
     private
@@ -44,7 +44,12 @@ module Monerorequest
       validate_amount!
       validate_payment_id!
       validate_start_date!
-      validate_days_per_billing_cycle!
+      if @request["version"] == 1 then
+        validate_days_per_billing_cycle!
+      end
+      if @request["version"] == 2 then
+        validate_schedule!
+      end
       validate_change_indicator_url!
     end
 
@@ -88,7 +93,7 @@ module Monerorequest
     end
 
     def validate_days_per_billing_cycle!
-      @errors.push("days_per_billing_cycle must be present.") unless @request.key?("days_per_billing_cycle")
+      @errors.push("days_per_billing_cycle must be present.") unless @request.key?("days_per_billing_cycle") && @request["version"] == '1'
       @errors.push("days_per_billing_cycle must be a Integer.") unless @request["days_per_billing_cycle"].is_a?(Integer)
     end
 
@@ -100,6 +105,11 @@ module Monerorequest
       return if @request["change_indicator_url"] =~ URI::DEFAULT_PARSER.make_regexp
 
       @errors.push("change_indicator_url must be a URL.")
+    end
+
+    def validate_schedule!
+      @errors.push("schedule must be present.") unless @request.key?("schedule")
+      @errors.push("schedule must be a valid Cron.") unless Cron.valid?(@request.fetch("schedule", ""))
     end
   end
 end

--- a/lib/monerorequest/encoder.rb
+++ b/lib/monerorequest/encoder.rb
@@ -23,7 +23,7 @@ module Monerorequest
     end
 
     def encode(version)
-      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1,2].include?(version.to_i)
+      raise RequestVersionError, "Request Versions 1 and 2 are supported." unless [1, 2].include?(version.to_i)
 
       json_str = @request.sort.to_h.to_json.force_encoding("ascii")
       compressed_data = StringIO.new
@@ -44,12 +44,8 @@ module Monerorequest
       validate_amount!
       validate_payment_id!
       validate_start_date!
-      if @request["version"] == 1 then
-        validate_days_per_billing_cycle!
-      end
-      if @request["version"] == 2 then
-        validate_schedule!
-      end
+      validate_days_per_billing_cycle! if @request["version"] == 1
+      validate_schedule! if @request["version"] == 2
       validate_change_indicator_url!
     end
 
@@ -93,7 +89,9 @@ module Monerorequest
     end
 
     def validate_days_per_billing_cycle!
-      @errors.push("days_per_billing_cycle must be present.") unless @request.key?("days_per_billing_cycle") && @request["version"] == '1'
+      unless @request.key?("days_per_billing_cycle") && @request["version"] == "1"
+        @errors.push("days_per_billing_cycle must be present.")
+      end
       @errors.push("days_per_billing_cycle must be a Integer.") unless @request["days_per_billing_cycle"].is_a?(Integer)
     end
 

--- a/spec/monerorequest/cron_spec.rb
+++ b/spec/monerorequest/cron_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe Monerorequest::Cron do
+  describe ".valid?" do
+    subject { described_class.valid?(cron) }
+  end
+
+  describe ".valid_minutes?" do
+    subject { described_class.valid_minutes?(minutes) }
+
+    context "when minutes are valid" do
+      let(:minutes) { (0..59).to_a }
+
+      it { is_expected.to be true }
+
+      let(:minutes) { ["*"] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when minutes are invalid" do
+      let(:minutes) { ['a'] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".valid_hours?" do
+    subject { described_class.valid_hours?(hours) }
+
+    context "when hours are valid" do
+      let(:hours) { (0..23).to_a }
+
+      it { is_expected.to be true }
+
+      let(:hours) { ["*"] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when hours are invalid" do
+      let(:hours) { ['a'] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".valid_days?" do
+    subject { described_class.valid_days?(days) }
+
+    context "when days are valid" do
+      let(:days) { (1..31).to_a }
+
+      it { is_expected.to be true }
+
+      let(:days) { ["*"] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when days are invalid" do
+      let(:days) { ['a'] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".valid_months?" do
+    subject { described_class.valid_months?(months) }
+
+    context "when months are valid" do
+      let(:months) { (1..12).to_a + described_class.MONTH_CODES }
+
+      it { is_expected.to be true }
+
+      let(:months) { ["*"] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when months are invalid" do
+      let(:months) { ['a'] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".valid_dow?" do
+    subject { described_class.valid_dow?(dow) }
+
+    context "when dows are valid" do
+      let(:dow) { described_class.DOW_CODES }
+
+      it { is_expected.to be true }
+
+      let(:dow) { ["*"] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when dows are invalid" do
+      let(:dow) { ['a'] }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".parse" do
+    subject { described_class.parse(cron) }
+
+    context "when schedule doesn't have 5 entries" do
+      let(:cron) { '* * * * * *' }
+
+      it { is_expected.to be false }
+
+      let(:cron) { '* * * *' }
+
+      it { is_expected.to be false }
+    end
+
+    context "when schedule has 5 entries" do
+      let(:cron) { '* * * * *' }
+
+      it "should return a parsed hash" do
+        expect(subject['minutes']).to eq ['*']
+        expect(subject['hours']).to eq ['*']
+        expect(subject['days']).to eq ['*']
+        expect(subject['months']).to eq ['*']
+        expect(subject['dow']).to eq ['*']
+      end
+    end
+
+    context "when schedule has delimited entries" do
+      let(:cron) { '24,36 2-4, 15,21 2,apr wed-fri' }
+
+      it "should return arrays" do
+        expect(subject['minutes']).to eq(['24', '36'])
+        expect(subject['hours']).to eq(['2', '4'])
+        expect(subject['days']).to eq(['15', '21'])
+        expect(subject['months']).to eq(['2', 'apr'])
+        expect(subject['dow']).to eq(['wed', 'fri'])
+      end
+    end
+  end
+end

--- a/spec/monerorequest/decoder_spec.rb
+++ b/spec/monerorequest/decoder_spec.rb
@@ -1,40 +1,83 @@
 # frozen_string_literal: true
 
 RSpec.describe Monerorequest::Decoder do
-  let(:decoded_request) do
-    {
-      "custom_label" => Faker::String.random,
-      "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
-      "currency" => Faker::Currency.code,
-      "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
-      "payment_id" => SecureRandom.hex(8),
-      "start_date" => DateTime.now.rfc3339,
-      "days_per_billing_cycle" => Faker::Number.number(digits: 2),
-      "number_of_payments" => Faker::Number.number(digits: 2),
-      "change_indicator_url" => Faker::Internet.url
-    }
-  end
-
-  describe "#decode" do
-    # to test encoding, we first encode and then decode and verify because the encoded string
-    # varies based on the OS the program is being run on due to the way gzip works.
-    subject(:decode) { decoder.decode }
-
-    let(:decoder) { described_class.new(encoded_request) }
-    let(:encoded_request) { Monerorequest::Encoder.new(decoded_request).encode(request_version) }
-
-    context "when invalid request_version is sent" do
-      let(:request_version) { 2 }
-
-      it "raises an error" do
-        expect { decode }.to raise_error(Monerorequest::RequestVersionError, "Only Request Version 1 is supported.")
-      end
+  context "v1" do
+    let(:decoded_request) do
+      {
+        "custom_label" => Faker::String.random,
+        "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
+        "currency" => Faker::Currency.code,
+        "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
+        "payment_id" => SecureRandom.hex(8),
+        "start_date" => DateTime.now.rfc3339,
+        "days_per_billing_cycle" => Faker::Number.number(digits: 2),
+        "number_of_payments" => Faker::Number.number(digits: 2),
+        "change_indicator_url" => Faker::Internet.url,
+        "version" => 1
+      }
     end
 
-    context "when valid request_version is sent" do
-      let(:request_version) { 1 }
+    describe "#decode" do
+      # to test encoding, we first encode and then decode and verify because the encoded string
+      # varies based on the OS the program is being run on due to the way gzip works.
+      subject(:decode) { decoder.decode }
 
-      it { is_expected.to eq(decoded_request) }
+      let(:decoder) { described_class.new(encoded_request) }
+      let(:encoded_request) { Monerorequest::Encoder.new(decoded_request).encode(request_version) }
+
+      context "when invalid request_version is sent" do
+        let(:request_version) { 3 }
+
+        it "raises an error" do
+          expect { decode }.to raise_error(Monerorequest::RequestVersionError, "Request Versions 1 and 2 are supported.")
+        end
+      end
+
+      context "when valid request_version is sent" do
+        let(:request_version) { 1 }
+
+        it { is_expected.to eq(decoded_request) }
+      end
+    end
+  end
+
+  context "v2" do
+    let(:decoded_request) do
+      {
+        "custom_label" => Faker::String.random,
+        "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
+        "currency" => Faker::Currency.code,
+        "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
+        "payment_id" => SecureRandom.hex(8),
+        "start_date" => DateTime.now.rfc3339,
+        "days_per_billing_cycle" => Faker::Number.number(digits: 2),
+        "number_of_payments" => Faker::Number.number(digits: 2),
+        "change_indicator_url" => Faker::Internet.url,
+        "version" => 2
+      }
+    end
+
+    describe "#decode" do
+      # to test encoding, we first encode and then decode and verify because the encoded string
+      # varies based on the OS the program is being run on due to the way gzip works.
+      subject(:decode) { decoder.decode }
+
+      let(:decoder) { described_class.new(encoded_request) }
+      let(:encoded_request) { Monerorequest::Encoder.new(decoded_request).encode(request_version) }
+
+      context "when invalid request_version is sent" do
+        let(:request_version) { 3 }
+
+        it "raises an error" do
+          expect { decode }.to raise_error(Monerorequest::RequestVersionError, "Request Versions 1 and 2 are supported.")
+        end
+      end
+
+      context "when valid request_version is sent" do
+        let(:request_version) { 2 }
+
+        it { is_expected.to eq(decoded_request) }
+      end
     end
   end
 end

--- a/spec/monerorequest/encoder_spec.rb
+++ b/spec/monerorequest/encoder_spec.rb
@@ -1,188 +1,380 @@
 # frozen_string_literal: true
 
 RSpec.describe Monerorequest::Encoder do
-  let(:decoded_request) do
-    {
-      "custom_label" => Faker::String.random,
-      "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
-      "currency" => Faker::Currency.code,
-      "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
-      "payment_id" => SecureRandom.hex(8),
-      "start_date" => DateTime.now.rfc3339,
-      "days_per_billing_cycle" => Faker::Number.number(digits: 2),
-      "number_of_payments" => Faker::Number.number(digits: 2),
-      "change_indicator_url" => Faker::Internet.url
-    }
+  context "V1" do
+    let(:decoded_request) do
+      {
+        "custom_label" => Faker::String.random,
+        "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
+        "currency" => Faker::Currency.code,
+        "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
+        "payment_id" => SecureRandom.hex(8),
+        "start_date" => DateTime.now.rfc3339,
+        "days_per_billing_cycle" => Faker::Number.number(digits: 2),
+        "number_of_payments" => Faker::Number.number(digits: 2),
+        "change_indicator_url" => Faker::Internet.url,
+        "version" => 1
+      }
+    end
+
+    describe "#initialize" do
+      subject(:encoder) { described_class.new(request.merge('version' => 1)) }
+
+      context "when custom_label is missing" do
+        let(:request) { {} }
+
+        it "contains a message about custom_label missing" do
+          expect(encoder.errors).to include("custom_label must be present.")
+        end
+      end
+
+      context "when custom_label is not a String" do
+        let(:request) { { "custom_label" => 1 } }
+
+        it "contains a message about custom_label not being a String" do
+          expect(encoder.errors).to include("custom_label must be a String.")
+        end
+      end
+
+      context "when sellers_wallet is missing" do
+        let(:request) { {} }
+
+        it "contains a message about sellers_wallet missing" do
+          expect(encoder.errors).to include("sellers_wallet must be present.")
+        end
+      end
+
+      context "when sellers_wallet is not a main Monero wallet address" do
+        let(:request) { { "sellers_wallet" => 123 } }
+
+        it "contains a message about sellers_wallet not being a main Monero address" do
+          expect(encoder.errors).to include("sellers_wallet must be a main Monero address.")
+        end
+      end
+
+      context "when currency is missing" do
+        let(:request) { {} }
+
+        it "contains a message about currency missing" do
+          expect(encoder.errors).to include("currency must be present.")
+        end
+      end
+
+      context "when currency is not a String" do
+        let(:request) { { "currency " => 1 } }
+
+        it "contains a message about currency not being a String" do
+          expect(encoder.errors).to include("currency must be a String.")
+        end
+      end
+
+      context "when amount is missing" do
+        let(:request) { {} }
+
+        it "contains a message about amount missing" do
+          expect(encoder.errors).to include("amount must be present.")
+        end
+      end
+
+      context "when amount is not a Numeric" do
+        let(:request) { { "amount" => "abc" } }
+
+        it "contains a message about amount not being a Numeric" do
+          expect(encoder.errors).to include("amount must be a Numeric.")
+        end
+      end
+
+      context "when payment_id is missing" do
+        let(:request) { {} }
+
+        it "contains a message about payment_id missing" do
+          expect(encoder.errors).to include("payment_id must be present.")
+        end
+      end
+
+      context "when payment_id is not a Monero Payment ID" do
+        let(:request) { { "payment_id" => 1 } }
+
+        it "contains a message about payment_id not being a Monero Payment ID" do
+          expect(encoder.errors).to include("payment_id must be a Monero Payment ID.")
+        end
+      end
+
+      context "when start_date is missing" do
+        let(:request) { {} }
+
+        it "contains a message about start_date missing" do
+          expect(encoder.errors).to include("start_date must be present.")
+        end
+      end
+
+      context "when start_date is not a String" do
+        let(:request) { { "start_date" => 1 } }
+
+        it "contains a message about start_date not being a String" do
+          expect(encoder.errors).to include("start_date must be a String.")
+        end
+      end
+
+      context "when start_date is not an RFC3339 timestamp" do
+        let(:request) { { "start_date" => "abc" } }
+
+        it "contains a message about start_date not being an RFC3339 timestamp" do
+          expect(encoder.errors).to include("start_date must be an RFC3339 timestamp.")
+        end
+      end
+
+      context "when days_per_billing_cycle is missing" do
+        let(:request) { {} }
+
+        it "contains a message about days_per_billing_cycle missing" do
+          expect(encoder.errors).to include("days_per_billing_cycle must be present.")
+        end
+      end
+
+      context "when days_per_billing_cycle is not a Integer" do
+        let(:request) { { "days_per_billing_cycle" => "abc" } }
+
+        it "contains a message about days_per_billing_cycle not being a Integer" do
+          expect(encoder.errors).to include("days_per_billing_cycle must be a Integer.")
+        end
+      end
+
+      context "when change_indicator_url is missing" do
+        let(:request) { {} }
+
+        it "contains a message about change_indicator_url missing" do
+          expect(encoder.errors).to include("change_indicator_url must be present.")
+        end
+      end
+
+      context "when change_indicator_url is not a String" do
+        let(:request) { { "days_per_billing_cycle" => 1 } }
+
+        it "contains a message about change_indicator_url not being a String" do
+          expect(encoder.errors).to include("change_indicator_url must be a String.")
+        end
+      end
+
+      context "when change_indicator_url is not a URL" do
+        let(:request) { { "change_indicator_url" => 1 } }
+
+        it "contains a message about change_indicator_url not being a URL" do
+          expect(encoder.errors).to include("change_indicator_url must be a URL.")
+        end
+      end
+    end
+
+    describe "#encode" do
+      # to test encoding, we first encode and then decode and verify because the encoded string
+      # varies based on the OS the program is being run on due to the way gzip works.
+      subject(:encode) { decoder.decode }
+
+      let(:encoder) { described_class.new(decoded_request) }
+      let(:decoder) { Monerorequest::Decoder.new(encoder.encode(request_version)) }
+
+      context "when invalid request_version is sent" do
+        let(:request_version) { 3 }
+
+        it "raises an error" do
+          expect { encode }.to raise_error(Monerorequest::RequestVersionError, "Request Versions 1 and 2 are supported.")
+        end
+      end
+
+      context "when valid request_version is sent" do
+        let(:request_version) { 1 }
+
+        it { is_expected.to eq(decoded_request) }
+      end
+    end
   end
 
-  describe "#initialize" do
-    subject(:encoder) { described_class.new(request) }
+  context "V2" do
+    let(:decoded_request) do
+      {
+        "custom_label" => Faker::String.random,
+        "sellers_wallet" => "4A#{Faker::Alphanumeric.alphanumeric(number: 93)}",
+        "currency" => Faker::Currency.code,
+        "amount" => Faker::Number.decimal(l_digits: 5, r_digits: 2),
+        "payment_id" => SecureRandom.hex(8),
+        "start_date" => DateTime.now.rfc3339,
+        "days_per_billing_cycle" => Faker::Number.number(digits: 2),
+        "number_of_payments" => Faker::Number.number(digits: 2),
+        "change_indicator_url" => Faker::Internet.url,
+        "schedule" => '* * * * *',
+        "version" => 2
+      }
+    end
 
-    context "when custom_label is missing" do
-      let(:request) { {} }
+    describe "#initialize" do
+      subject(:encoder) { described_class.new(request.merge('version' => 2)) }
 
-      it "contains a message about custom_label missing" do
-        expect(encoder.errors).to include("custom_label must be present.")
+      context "when custom_label is missing" do
+        let(:request) { {} }
+
+        it "contains a message about custom_label missing" do
+          expect(encoder.errors).to include("custom_label must be present.")
+        end
+      end
+
+      context "when custom_label is not a String" do
+        let(:request) { { "custom_label" => 1 } }
+
+        it "contains a message about custom_label not being a String" do
+          expect(encoder.errors).to include("custom_label must be a String.")
+        end
+      end
+
+      context "when sellers_wallet is missing" do
+        let(:request) { {} }
+
+        it "contains a message about sellers_wallet missing" do
+          expect(encoder.errors).to include("sellers_wallet must be present.")
+        end
+      end
+
+      context "when sellers_wallet is not a main Monero wallet address" do
+        let(:request) { { "sellers_wallet" => 123 } }
+
+        it "contains a message about sellers_wallet not being a main Monero address" do
+          expect(encoder.errors).to include("sellers_wallet must be a main Monero address.")
+        end
+      end
+
+      context "when currency is missing" do
+        let(:request) { {} }
+
+        it "contains a message about currency missing" do
+          expect(encoder.errors).to include("currency must be present.")
+        end
+      end
+
+      context "when currency is not a String" do
+        let(:request) { { "currency " => 1 } }
+
+        it "contains a message about currency not being a String" do
+          expect(encoder.errors).to include("currency must be a String.")
+        end
+      end
+
+      context "when amount is missing" do
+        let(:request) { {} }
+
+        it "contains a message about amount missing" do
+          expect(encoder.errors).to include("amount must be present.")
+        end
+      end
+
+      context "when amount is not a Numeric" do
+        let(:request) { { "amount" => "abc" } }
+
+        it "contains a message about amount not being a Numeric" do
+          expect(encoder.errors).to include("amount must be a Numeric.")
+        end
+      end
+
+      context "when payment_id is missing" do
+        let(:request) { {} }
+
+        it "contains a message about payment_id missing" do
+          expect(encoder.errors).to include("payment_id must be present.")
+        end
+      end
+
+      context "when payment_id is not a Monero Payment ID" do
+        let(:request) { { "payment_id" => 1 } }
+
+        it "contains a message about payment_id not being a Monero Payment ID" do
+          expect(encoder.errors).to include("payment_id must be a Monero Payment ID.")
+        end
+      end
+
+      context "when start_date is missing" do
+        let(:request) { {} }
+
+        it "contains a message about start_date missing" do
+          expect(encoder.errors).to include("start_date must be present.")
+        end
+      end
+
+      context "when start_date is not a String" do
+        let(:request) { { "start_date" => 1 } }
+
+        it "contains a message about start_date not being a String" do
+          expect(encoder.errors).to include("start_date must be a String.")
+        end
+      end
+
+      context "when start_date is not an RFC3339 timestamp" do
+        let(:request) { { "start_date" => "abc" } }
+
+        it "contains a message about start_date not being an RFC3339 timestamp" do
+          expect(encoder.errors).to include("start_date must be an RFC3339 timestamp.")
+        end
+      end
+
+      context "when schedule is missing" do
+        let(:request) { {} }
+
+        it "contains a message about schedule missing" do
+          expect(encoder.errors).to include("schedule must be present.")
+        end
+      end
+
+      context "when schedule is not a valid Cron" do
+        let(:request) { { "schedule" => "abc" } }
+
+        it "contains a message about schedule not being a valid Cron" do
+          expect(encoder.errors).to include("schedule must be a valid Cron.")
+        end
+      end
+
+      context "when change_indicator_url is missing" do
+        let(:request) { {} }
+
+        it "contains a message about change_indicator_url missing" do
+          expect(encoder.errors).to include("change_indicator_url must be present.")
+        end
+      end
+
+      context "when change_indicator_url is not a String" do
+        let(:request) { { "days_per_billing_cycle" => 1 } }
+
+        it "contains a message about change_indicator_url not being a String" do
+          expect(encoder.errors).to include("change_indicator_url must be a String.")
+        end
+      end
+
+      context "when change_indicator_url is not a URL" do
+        let(:request) { { "change_indicator_url" => 1 } }
+
+        it "contains a message about change_indicator_url not being a URL" do
+          expect(encoder.errors).to include("change_indicator_url must be a URL.")
+        end
       end
     end
 
-    context "when custom_label is not a String" do
-      let(:request) { { "custom_label" => 1 } }
+    describe "#encode" do
+      # to test encoding, we first encode and then decode and verify because the encoded string
+      # varies based on the OS the program is being run on due to the way gzip works.
+      subject(:encode) { decoder.decode }
 
-      it "contains a message about custom_label not being a String" do
-        expect(encoder.errors).to include("custom_label must be a String.")
+      let(:encoder) { described_class.new(decoded_request) }
+      let(:decoder) { Monerorequest::Decoder.new(encoder.encode(request_version)) }
+
+      context "when invalid request_version is sent" do
+        let(:request_version) { 3 }
+
+        it "raises an error" do
+          expect { encode }.to raise_error(Monerorequest::RequestVersionError, "Request Versions 1 and 2 are supported.")
+        end
       end
-    end
 
-    context "when sellers_wallet is missing" do
-      let(:request) { {} }
+      context "when valid request_version is sent" do
+        let(:request_version) { 2 }
 
-      it "contains a message about sellers_wallet missing" do
-        expect(encoder.errors).to include("sellers_wallet must be present.")
+        it { is_expected.to eq(decoded_request)}
       end
-    end
-
-    context "when sellers_wallet is not a main Monero wallet address" do
-      let(:request) { { "sellers_wallet" => 123 } }
-
-      it "contains a message about sellers_wallet not being a main Monero address" do
-        expect(encoder.errors).to include("sellers_wallet must be a main Monero address.")
-      end
-    end
-
-    context "when currency is missing" do
-      let(:request) { {} }
-
-      it "contains a message about currency missing" do
-        expect(encoder.errors).to include("currency must be present.")
-      end
-    end
-
-    context "when currency is not a String" do
-      let(:request) { { "currency " => 1 } }
-
-      it "contains a message about currency not being a String" do
-        expect(encoder.errors).to include("currency must be a String.")
-      end
-    end
-
-    context "when amount is missing" do
-      let(:request) { {} }
-
-      it "contains a message about amount missing" do
-        expect(encoder.errors).to include("amount must be present.")
-      end
-    end
-
-    context "when amount is not a Numeric" do
-      let(:request) { { "amount" => "abc" } }
-
-      it "contains a message about amount not being a Numeric" do
-        expect(encoder.errors).to include("amount must be a Numeric.")
-      end
-    end
-
-    context "when payment_id is missing" do
-      let(:request) { {} }
-
-      it "contains a message about payment_id missing" do
-        expect(encoder.errors).to include("payment_id must be present.")
-      end
-    end
-
-    context "when payment_id is not a Monero Payment ID" do
-      let(:request) { { "payment_id" => 1 } }
-
-      it "contains a message about payment_id not being a Monero Payment ID" do
-        expect(encoder.errors).to include("payment_id must be a Monero Payment ID.")
-      end
-    end
-
-    context "when start_date is missing" do
-      let(:request) { {} }
-
-      it "contains a message about start_date missing" do
-        expect(encoder.errors).to include("start_date must be present.")
-      end
-    end
-
-    context "when start_date is not a String" do
-      let(:request) { { "start_date" => 1 } }
-
-      it "contains a message about start_date not being a String" do
-        expect(encoder.errors).to include("start_date must be a String.")
-      end
-    end
-
-    context "when start_date is not an RFC3339 timestamp" do
-      let(:request) { { "start_date" => "abc" } }
-
-      it "contains a message about start_date not being an RFC3339 timestamp" do
-        expect(encoder.errors).to include("start_date must be an RFC3339 timestamp.")
-      end
-    end
-
-    context "when days_per_billing_cycle is missing" do
-      let(:request) { {} }
-
-      it "contains a message about days_per_billing_cycle missing" do
-        expect(encoder.errors).to include("days_per_billing_cycle must be present.")
-      end
-    end
-
-    context "when days_per_billing_cycle is not a Integer" do
-      let(:request) { { "days_per_billing_cycle" => "abc" } }
-
-      it "contains a message about days_per_billing_cycle not being a Integer" do
-        expect(encoder.errors).to include("days_per_billing_cycle must be a Integer.")
-      end
-    end
-
-    context "when change_indicator_url is missing" do
-      let(:request) { {} }
-
-      it "contains a message about change_indicator_url missing" do
-        expect(encoder.errors).to include("change_indicator_url must be present.")
-      end
-    end
-
-    context "when change_indicator_url is not a String" do
-      let(:request) { { "days_per_billing_cycle" => 1 } }
-
-      it "contains a message about change_indicator_url not being a String" do
-        expect(encoder.errors).to include("change_indicator_url must be a String.")
-      end
-    end
-
-    context "when change_indicator_url is not a URL" do
-      let(:request) { { "change_indicator_url" => 1 } }
-
-      it "contains a message about change_indicator_url not being a URL" do
-        expect(encoder.errors).to include("change_indicator_url must be a URL.")
-      end
-    end
-  end
-
-  describe "#encode" do
-    # to test encoding, we first encode and then decode and verify because the encoded string
-    # varies based on the OS the program is being run on due to the way gzip works.
-    subject(:encode) { decoder.decode }
-
-    let(:encoder) { described_class.new(decoded_request) }
-    let(:decoder) { Monerorequest::Decoder.new(encoder.encode(request_version)) }
-
-    context "when invalid request_version is sent" do
-      let(:request_version) { 2 }
-
-      it "raises an error" do
-        expect { encode }.to raise_error(Monerorequest::RequestVersionError, "Only Request Version 1 is supported.")
-      end
-    end
-
-    context "when valid request_version is sent" do
-      let(:request_version) { 1 }
-
-      it { is_expected.to eq(decoded_request) }
     end
   end
 end


### PR DESCRIPTION
There's some [proposed changes](https://github.com/lukeprofits/Monero_Payment_Request_Standard/pull/9) to the Monero Payment Request Standard to upgrade to a v2 which will change the scheduling mechanism of the standard. This is a set of changes to implement that change. Feedback on the proposed changes to the standard or this PR are welcome.